### PR TITLE
:wrench: chore(actions): add a GitHub action to lint PR title

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,78 @@
+name: Lint pull request title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+## Pattern to match strings as follows:
+# ✨ feature(ui): Add `Button` component.
+# ^  ^    ^    ^
+# |  |    |    |__ Subject
+# |  |    |_______ Scope
+# |  |____________ Type
+# |_______________ Emoji (for the related type)
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    name: lint
+    steps:
+      - name: Validate PR title
+        id: lint_pr_title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          headerPattern: '^(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|:\w*:) (\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$'
+          headerPatternCorrespondence: emoji, type, scope, subject
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+            wip
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to be formatted as follows:
+            ```
+            ✨ feature(ui): Add `Button` component.
+            ^  ^    ^    ^
+            |  |    |    |__ Subject
+            |  |    |_______ Scope
+            |  |____________ Type
+            |_______________ Emoji (for the related type)
+            ```
+
+            The current title does not match this format.
+            <details>
+              <summary>Error details 👀</summary>
+              
+              ```
+              ${{ steps.lint_pr_title.outputs.error_message }}
+              ```
+            </details>
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
# 🎯 Goal

In this PR, I configured a GitHub action to validate the name of our PR like we validate our commits.

# 🧠 Approach

Thanks to the `headerPattern`, I define a regexp of how the PR name must be validated.

```
## Pattern to match strings as follows:
# ✨ feature(ui): Add `Button` component.
# ^  ^    ^    ^
# |  |    |    |__ Subject
# |  |    |_______ Scope
# |  |____________ Type
# |_______________ Emoji (for the related type)
```

If the PR title does not match this format, a comment is written by a bot.
![image](https://user-images.githubusercontent.com/17927632/214262269-ffc36779-fb61-487e-a5ac-c18955b692b5.png)

Once the PR has been fixed and satisfies the required format, the comment is deleted.